### PR TITLE
feat(xlsx-manual): add XLSX manual importer; prompt for path, unify debit/credit, publish latest balance

### DIFF
--- a/src/application/account_manager/xlsx_manual_account_manager.py
+++ b/src/application/account_manager/xlsx_manual_account_manager.py
@@ -1,0 +1,108 @@
+import datetime
+from typing import List, Optional
+
+from src.application.account_manager.i_account_manager import IAccountManager
+from src.application.account_manager.exceptions import AccountNotFoundException
+from src.domain.category_taggers.i_tagger import ITagger
+from src.domain.transactions import ITransaction, FromListTransaction
+from src.infrastructure.bank_account_transactions_fetchers.i_transactions_fetcher import (
+    ITransactionsFetcher,
+)
+from src.infrastructure.bank_account_transactions_fetchers.xlsx_transactions_fetcher import (
+    XlsxTransactionsFetcher,
+)
+from src.domain.balance import Balance
+
+
+class XlsxManualAccountManager(IAccountManager):
+    def __init__(
+        self,
+        account_name: str,
+        header_skip_rows: int,
+        date_format: str,
+        decimal_separator: str,
+        thousands_separator: str,
+        columns: dict,
+        remove_transaction_description_prefix: bool,
+        taggers: List[ITagger],
+        sheet_name: Optional[str] = None,
+        prompt_for_file_path: bool = True,
+        file_path: Optional[str] = None,
+    ):
+        self.account_name = account_name
+        self.taggers = taggers
+        self.remove_transactions_description_prefix = (
+            remove_transaction_description_prefix
+        )
+        self.prompt_for_file_path = prompt_for_file_path
+        self.file_path = file_path
+        self.sheet_name = sheet_name
+        self.transactions_fetcher: ITransactionsFetcher = XlsxTransactionsFetcher(
+            header_skip_rows=header_skip_rows,
+            date_format=date_format,
+            decimal_separator=decimal_separator,
+            thousands_separator=thousands_separator,
+            columns=columns,
+            sheet_name=sheet_name,
+        )
+        self._latest_balance_value: Optional[float] = None
+        self._latest_balance_date: Optional[datetime.datetime] = None
+        self.account_names = None
+
+    def set_accounts(self, account_names: List[str]) -> None:
+        self.account_names = account_names
+
+    def _resolve_file_path(self) -> str:
+        if self.file_path:
+            return self.file_path
+        if self.prompt_for_file_path:
+            path = input(
+                f"Please enter the path to the XLSX file for '{self.account_name}': "
+            ).strip()
+            if not path:
+                raise Exception("No file path provided")
+            self.file_path = path
+            return path
+        raise Exception("file_path not set and prompt_for_file_path is False")
+
+    def _get_transactions(
+        self, date_start: datetime, date_end: datetime
+    ) -> List[ITransaction]:
+        path = self._resolve_file_path()
+        raw_rows = self.transactions_fetcher.getTransactions(
+            date_init=date_start, date_end=date_end, file_path=path
+        )
+
+        # Track latest balance
+        self._latest_balance_value = None
+        self._latest_balance_date = None
+
+        txs: List[ITransaction] = []
+        for row in raw_rows:
+            capture = row["captureDate"].strftime("%Y/%m/%d")
+            auth = row["authDate"].strftime("%Y/%m/%d")
+            desc = row["description"]
+            amount = row["amount"]
+            txs.append(FromListTransaction(capture, auth, desc, amount))
+
+            if row.get("balance") is not None:
+                self._latest_balance_value = row["balance"]
+                self._latest_balance_date = row["authDate"] or row["captureDate"]
+
+        return txs
+
+    def getCategoryTaggers(self) -> List[ITagger]:
+        return self.taggers
+
+    def close(self):
+        pass
+
+    def get_balance(self) -> Balance:
+        if self._latest_balance_value is not None:
+            return Balance(
+                balance_date=self._latest_balance_date,
+                updated_date_time=datetime.datetime.now(),
+                balance=self._latest_balance_value,
+                account=None,
+            )
+        return None

--- a/src/infrastructure/bank_account_transactions_fetchers/xlsx_transactions_fetcher.py
+++ b/src/infrastructure/bank_account_transactions_fetchers/xlsx_transactions_fetcher.py
@@ -1,0 +1,99 @@
+from typing import List, Dict, Optional
+from datetime import datetime
+from openpyxl import load_workbook
+
+from src.infrastructure.bank_account_transactions_fetchers.i_transactions_fetcher import (
+    ITransactionsFetcher,
+)
+
+
+class XlsxTransactionsFetcher(ITransactionsFetcher):
+    def __init__(
+        self,
+        header_skip_rows: int,
+        date_format: str,
+        decimal_separator: str,
+        thousands_separator: str,
+        columns: Dict[str, str],
+        sheet_name: Optional[str] = None,
+    ):
+        self.header_skip_rows = header_skip_rows
+        self.date_format = date_format
+        self.decimal_separator = decimal_separator
+        self.thousands_separator = thousands_separator
+        self.columns = columns
+        self.sheet_name = sheet_name
+
+    def _parse_date(self, value) -> Optional[datetime]:
+        if value is None or value == "":
+            return None
+        if isinstance(value, datetime):
+            return value
+        # treat as string
+        return datetime.strptime(str(value).strip(), self.date_format)
+
+    def _parse_amount(self, value: Optional[str]) -> float:
+        if value is None or value == "":
+            return 0.0
+        s = str(value).strip()
+        if self.thousands_separator:
+            s = s.replace(self.thousands_separator, "")
+        if self.decimal_separator and self.decimal_separator != ".":
+            s = s.replace(self.decimal_separator, ".")
+        return float(s)
+
+    def getTransactions(
+        self, date_init: datetime = None, date_end: datetime = None, file_path: str = None
+    ) -> List[Dict[str, object]]:
+        if not file_path:
+            raise Exception("file_path must be provided to XlsxTransactionsFetcher")
+        wb = load_workbook(filename=file_path, data_only=True)
+        ws = wb[self.sheet_name] if self.sheet_name else wb.worksheets[0]
+
+        # Build header index from the first non-skipped row
+        header_row_idx = self.header_skip_rows + 1
+        headers = [c.value for c in ws[header_row_idx]]
+        col_idx = {h: i for i, h in enumerate(headers)}
+
+        def idx(name: str) -> int:
+            if name not in col_idx:
+                raise Exception(f"Column '{name}' not found in XLSX headers")
+            return col_idx[name]
+
+        rows = []
+        for row in ws.iter_rows(min_row=header_row_idx + 1, values_only=True):
+            capture = self._parse_date(row[idx(self.columns["capture_date"])])
+            auth = self._parse_date(row[idx(self.columns.get("auth_date", self.columns["capture_date"]))])
+            if auth is None:
+                auth = capture
+            description = row[idx(self.columns["description"])].strip()
+            debit = self._parse_amount(row[idx(self.columns["debit"])])
+            credit = self._parse_amount(row[idx(self.columns["credit"])])
+            amount = credit - debit
+            balance = None
+            if "balance" in self.columns:
+                try:
+                    balance = self._parse_amount(row[idx(self.columns["balance"])])
+                except Exception:
+                    balance = None
+
+            if capture is None and auth is None:
+                continue
+
+            # Date range filter
+            if date_init is not None and auth.date() < date_init.date():
+                continue
+            if date_end is not None and auth.date() > date_end.date():
+                continue
+
+            rows.append(
+                {
+                    "captureDate": capture,
+                    "authDate": auth,
+                    "description": description,
+                    "amount": amount,
+                    "balance": balance,
+                }
+            )
+
+        return rows


### PR DESCRIPTION
Implements #5

Adds a new manual account type  that prompts for an XLSX file path at runtime, parses a single-sheet export with non-transaction header rows, unifies debit/credit into a signed amount, and stages rows into the repository-first flow (Google Sheets). Also publishes the latest balance to the Accounts Balance sheet.

- New fetcher: XlsxTransactionsFetcher (openpyxl)
- New account manager: XlsxManualAccountManager
- Config parser: supports  with mapping and separators

Config example:


Acceptance criteria:
- Prompts for path; parses and stages rows with unified signed amounts
- Dates normalized to %Y-%m-%d in staged output
- Taggers apply; MBWay matches remain uncategorized
- Latest balance appended with balance date and updated timestamp
- Skips gracefully if user cancels path input

Manual-first by design; no watch-folder automation yet.
